### PR TITLE
Fix malfunction on data sync issue

### DIFF
--- a/app/src/main/java/com/example/todocloud/fragment/MainListFragment.java
+++ b/app/src/main/java/com/example/todocloud/fragment/MainListFragment.java
@@ -1033,6 +1033,7 @@ public class MainListFragment extends ListFragment implements
   @Override
   public void onFinishSyncListData() {
     updateListAdapter();
+    updateCategoryAdapter();
   }
 
   @Override


### PR DESCRIPTION
How to reproduce the issue:

1. Move a list.
2. Perform data sync.
3. Move the same list again.
4. Repeat step 2.

Description of the issue:

The list, moved in step 1 to somewhere. It will be there again after
step 4.

Cause of the issue:
The UpdateAdapter tasks can be performed before data synchronization
process has finished. The TodoDataSynchronizer, ListDataSynchronizer and
CategoryDataSynchronizer call their own onFinishedDataSynchronization
interface methods before the process is actually finished, in some
cases.

---

Issue:
[#5] (https://github.com/rolandvitezhu/TodoCloud/issues/5)